### PR TITLE
fix(requirements): use langchain-core instead of langraph-core (#1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 langgraph==0.3.21
-langgraph-core==0.3.49
+langchain-core==0.3.49
 langgraph-cli==0.1.73
 langchain-openai==0.3.11
 python-dotenv==1.1.0


### PR DESCRIPTION
This PR fixes #1 by replacing `langraph-core` with the correct package `langchain-core` in `requirements.txt`.
